### PR TITLE
Save duration as a tag (e.g. `15m`)

### DIFF
--- a/OmniToggl.omnifocusjs/Resources/startTogglTimer.js
+++ b/OmniToggl.omnifocusjs/Resources/startTogglTimer.js
@@ -62,7 +62,10 @@
       }
       console.log('pid is: ', pid);
 
-      const taskTags = source.tags.map((t) => t.name);
+      let taskTags = source.tags.map((t) => t.name);
+      taskTags.push(`${source.duration > 0 ? source.duration : 15}m`);
+
+
 
       try {
         const r = await startTogglTimer({


### PR DESCRIPTION
The Problem:
============
I use [Huginn](https://github.com/huginn/huginn) to monitor my Toggl data and take actions. One such action is to send me a notification if my current task is overruning. For that to happen, Toggl has to know in advance how long a task is expected to take and for that I use tags: `15m`, `30m`, etc.

Tasks sent from OmniFocus push their tags to Toggl, but the estimated duration isn't expressed as a tag here.

The Solution:
=============
When starting a task get the estimated duration expressed in minutes (or default to 15). Format this as `<duration>m` and append to the `taskTags` list before we talk to Toggl.