### PR TITLE
Switch to v9 API

### DIFF
--- a/OmniToggl.omnifocusjs/Resources/common.js
+++ b/OmniToggl.omnifocusjs/Resources/common.js
@@ -116,7 +116,7 @@
       throw buildErrorObject(r);
     }
 
-    return JSON.parse(r.bodyString).data;
+    return JSON.parse(r.bodyString);
   };
 
   dependencyLibrary.createTogglProject = async function createTogglProject(

--- a/OmniToggl.omnifocusjs/Resources/common.js
+++ b/OmniToggl.omnifocusjs/Resources/common.js
@@ -3,6 +3,8 @@
 (() => {
   // Replace the string below with your API Token found here: https://track.toggl.com/profile
   const TOGGL_AUTH_TOKEN = 'REPLACE_ME';
+  // Time entries must be assigned to a workspace
+  const TOGGL_WORKSPACE_ID = 'REPLACE_ME_TOO';
   // Name of the tag we use to assign what you're working on
   // (this makes it easier to reset the changes made to the name)
   const TRACKING_TAG_NAME = 'working-on';
@@ -10,7 +12,8 @@
   // Replace this if you would like something different
   const TRACKING_NAME_PREFIX = '🎯';
 
-  const TOGGL_URL = 'https://api.track.toggl.com/api/v8';
+  const TOGGL_URL = 'https://api.track.toggl.com/api/v9/';
+  const TOGGL_WORKSPACED_URL = `${TOGGL_URL}workspaces/${TOGGL_WORKSPACE_ID}`;
 
   // the following is a pollyfill for base64 taken from https://github.com/MaxArt2501/base64-js/blob/master/base64.js
   function btoa(stringParam) {
@@ -55,10 +58,9 @@
     timeEntry,
   ) {
     const fetchRequest = new URL.FetchRequest();
+    timeEntry.wid = parseInt(TOGGL_WORKSPACE_ID);
     fetchRequest.bodyData = Data.fromString(
-      JSON.stringify({
-        time_entry: timeEntry,
-      }),
+      JSON.stringify(timeEntry)
     );
     fetchRequest.method = 'POST';
     fetchRequest.headers = {
@@ -66,7 +68,7 @@
       'Content-Type': 'application/json',
     };
     fetchRequest.url = URL.fromString(
-      `${TOGGL_URL}/time_entries/start`,
+      `${TOGGL_WORKSPACED_URL}/time_entries`
     );
     const r = await fetchRequest.fetch();
 
@@ -74,7 +76,7 @@
       throw buildErrorObject(r);
     }
 
-    return JSON.parse(r.bodyString).data;
+    return JSON.parse(r.bodyString);
   };
 
   dependencyLibrary.getCurrentTogglTimer = async function getCurrentTogglTimer() {
@@ -86,7 +88,7 @@
       'Content-Type': 'application/json',
     };
     fetchRequest.url = URL.fromString(
-      `${TOGGL_URL}/time_entries/current`,
+      `${TOGGL_URL}me/time_entries/current`
     );
     const r = await fetchRequest.fetch();
 
@@ -94,19 +96,19 @@
       throw buildErrorObject(r);
     }
 
-    return JSON.parse(r.bodyString).data;
+    return JSON.parse(r.bodyString);
   };
 
   dependencyLibrary.stopTogglTimer = async function stopTogglTimer(id) {
     const fetchRequest = new URL.FetchRequest();
 
-    fetchRequest.method = 'PUT';
+    fetchRequest.method = 'PATCH';
     fetchRequest.headers = {
       Authorization: AuthHeader,
       'Content-Type': 'application/json',
     };
     fetchRequest.url = URL.fromString(
-      `${TOGGL_URL}/time_entries/${id}/stop`,
+      `${TOGGL_WORKSPACED_URL}/time_entries/${id}/stop`
     );
     const r = await fetchRequest.fetch();
 
@@ -122,7 +124,7 @@
   ) {
     const fetchRequest = new URL.FetchRequest();
     fetchRequest.bodyData = Data.fromString(
-      JSON.stringify({ project: { name } }),
+      JSON.stringify({ name: name, active: true }),
     );
     fetchRequest.method = 'POST';
     fetchRequest.headers = {
@@ -130,7 +132,7 @@
       'Content-Type': 'application/json',
     };
     fetchRequest.url = URL.fromString(
-      `${TOGGL_URL}/projects`,
+      `${TOGGL_WORKSPACED_URL}/projects`,
     );
     const r = await fetchRequest.fetch();
 
@@ -138,7 +140,7 @@
       throw buildErrorObject(r);
     }
 
-    return JSON.parse(r.bodyString).data;
+    return JSON.parse(r.bodyString);
   };
 
   dependencyLibrary.getTogglProjects = async function getTogglProjects() {
@@ -149,15 +151,16 @@
       'Content-Type': 'application/json',
     };
     fetchRequest.url = URL.fromString(
-      `${TOGGL_URL}/me?with_related_data=true`,
+      `${TOGGL_WORKSPACED_URL}/projects`,
     );
+
     const r = await fetchRequest.fetch();
 
     if (r.statusCode !== 200) {
       throw buildErrorObject(r);
     }
 
-    return JSON.parse(r.bodyString).data.projects;
+    return JSON.parse(r.bodyString);
   };
 
   dependencyLibrary.log = async function log(message, title = 'Log') {

--- a/OmniToggl.omnifocusjs/Resources/startTogglTimer.js
+++ b/OmniToggl.omnifocusjs/Resources/startTogglTimer.js
@@ -40,7 +40,7 @@
       }
 
       const toggleProject = (projects || []).find(
-        (p) => p.name.trim().toLowerCase() === projectName.trim().toLowerCase(),
+        (p) => p.name.trim().toLowerCase() === projectName.trim().toLowerCase()
       );
 
       const taskName = source.name;
@@ -65,11 +65,11 @@
       let taskTags = source.tags.map((t) => t.name);
       taskTags.push(`${source.duration > 0 ? source.duration : 15}m`);
 
-
-
       try {
         const r = await startTogglTimer({
           description: taskName,
+          duration: Math.floor(-1 * Date.now()/1000),
+          start: new Date().toISOString(),
           created_with: 'omnifocus',
           tags: taskTags,
           pid,

--- a/OmniToggl.omnifocusjs/Resources/stopTogglTimer.js
+++ b/OmniToggl.omnifocusjs/Resources/stopTogglTimer.js
@@ -11,7 +11,8 @@
     try {
       const currentTimer = await getCurrentTogglTimer();
       if (currentTimer) {
-        await stopTogglTimer(currentTimer.id);
+        const r = await stopTogglTimer(currentTimer.id);
+        console.log('Timer started stopped', JSON.stringify(r));
       }
       resetTasks();
     } catch (e) {

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ When you highlight a task in OmniFocus and then kick off this automation, a time
 ![Omnifocus Dialog](img/Screenshot-4.png)
 7. Open `Resources/common.js` in your favourite text editor
 ![Omnifocus Dialog](img/Screenshot-6.png)
-8. Replace 'REPLACE_ME' with you toggl API Token that can be found [here](https://track.toggl.com/profile)
+8. Replace 'REPLACE_ME' with your toggl API Token that can be found [here](https://track.toggl.com/profile)
+8. Replace 'REPLACE_ME_TOO' with your [toggl workspace id](https://developers.track.toggl.com/docs/workspace), you can lift this from most URLs in the webapp
 9. Quit and Restart OmniFocus
 9. You should now be all set up and can start a timer by clicking on a task and choosing Automation > OmniToggle > Start Timer from the menu.
 


### PR DESCRIPTION
The Problem:
============
The [v8 API is deprecated](https://toggl.com/blog/toggl-track-api-v9).
I've found some oddities in it recently. The [v9 API](https://developers.track.toggl.com/docs/) is preferred

The Solution:
=============
The main difference between v8 and v9 is the [workspace id](https://developers.track.toggl.com/docs/workspace).
Most actions require a workspace section in the URL and/or as a param.

* Within `common.js` the URLs are updated to their v9 versions.
* The `start` endpoint is updated to pass some required parameters for start/duration.
* The returned json objects are no longer wrapped in a `data` key